### PR TITLE
append sync-ignored settings at the end instead of beginning.

### DIFF
--- a/src/services/pragma.ts
+++ b/src/services/pragma.ts
@@ -79,7 +79,7 @@ export class Pragma {
     const ignoredBlocks = Pragma.getIgnoredBlocks(localContent);
 
     if (ignoredBlocks) {
-      result = result.replace(/{\s*\n/, `{\n${ignoredBlocks}\n\n\n`);
+      result = result.replace(/}\s*\n/, `\n\n\n${ignoredBlocks}\n}`);
     }
 
     return result;

--- a/src/services/pragma.ts
+++ b/src/services/pragma.ts
@@ -79,7 +79,7 @@ export class Pragma {
     const ignoredBlocks = Pragma.getIgnoredBlocks(localContent);
 
     if (ignoredBlocks) {
-      result = result.replace(/}\s*\n/, `\n\n\n${ignoredBlocks}\n}`);
+      result = result.replace(/(\s*)\}(?![\s\S]*\s*\})/, `\n\n\n${ignoredBlocks}$1}`);
     }
 
     return result;

--- a/src/tests/services/pragma.test.ts
+++ b/src/tests/services/pragma.test.ts
@@ -25,31 +25,31 @@ it("should return new content if invalid", () => {
 
 it("should properly ignore", () => {
   const initial = `{
+    "xyz": "abc",
     // @sync-ignore
     "abc": "xyz",
     // @sync-ignore
-    "abc2": "xyz2",
-    "xyz": "abc"
+    "abc2": "xyz2"
   }`;
 
   const expected = `{
-    "xyz": "abc"
+    "xyz": "abc",
   }`;
 
   expect(Pragma.processOutgoing(initial)).toBe(expected);
 
   const initial2 = `{
-    "xyz": "def"
+    "xyz": "def",
   }`;
 
   const expected2 = `{
+    "xyz": "def",
+
+
     // @sync-ignore
     "abc": "xyz",
     // @sync-ignore
     "abc2": "xyz2",
-
-
-    "xyz": "def"
   }`;
 
   expect(Pragma.processIncoming("", initial2, initial)).toBe(expected2);


### PR DESCRIPTION

### What does this PR do?

This allows overriding synced settings with local preferences as
expected, instead of the local setting being retained, but ignored

### Changes

<!-- A concise list of all changes proposed. -->

- Change where ignored blocks are added into the result

### Tests

<!-- How was this pull request tested? -->

This PR was tested ... manually :)
