### PR TITLE
Fix sync-ignore for blocks and arrays.

### DIFF
--- a/src/services/pragma.ts
+++ b/src/services/pragma.ts
@@ -191,7 +191,12 @@ export class Pragma {
     let index = currentIndex;
     let currentLine = lines[++index];
 
-    if (checkTrailingComma && !currentLine.trim().endsWith(",")) {
+    const opensCurlyBraces = /{/.test(currentLine);
+    const opensBrackets = /".+"\s*:\s*\[/.test(currentLine);
+
+    let openedBlock = opensCurlyBraces || opensBrackets;
+
+    if (!openedBlock && checkTrailingComma && !currentLine.trim().endsWith(",")) {
       currentLine = `${currentLine.trimRight()},`;
     }
 
@@ -199,10 +204,6 @@ export class Pragma {
       parsedLines.push(Pragma.toggleComments(currentLine, shouldComment));
     }
 
-    const opensCurlyBraces = /{/.test(currentLine);
-    const opensBrackets = /".+"\s*:\s*\[/.test(currentLine);
-
-    let openedBlock = opensCurlyBraces ?? opensBrackets;
     if (openedBlock) {
       while (openedBlock) {
         currentLine = lines[++index];


### PR DESCRIPTION
### What does this PR do?

Fixes the behavior of the sync-ignore pragma for blocks (objects) and arrays.
Previously, the body of a block or array would be eaten and a redundant trailing comma appended.

### Changes

<!-- A concise list of all changes proposed. -->

- Change `CheckNextLines` slightly so it works as intended.

### Tests

<!-- How was this pull request tested? -->

This PR was tested ... manually :)